### PR TITLE
update Ledger Rust SDK deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,12 +31,9 @@ optional = true
 "logging" = [ "ledger-log" ]
 
 [target.'cfg(target_family = "bolos")'.dependencies]
-ledger_device_sdk = { version = "1.28.0" }
+ledger_device_sdk = { version = "1.29.0" }
 
 [target.'cfg(target_family = "bolos")'.dev-dependencies]
 testmacro = "0.1.0"
-ledger_device_sdk = { version = "1.28.0", features = ["speculos"] }
-
-[patch.crates-io]
-ledger_device_sdk = { git = "https://github.com/LedgerHQ/ledger-device-rust-sdk.git" }
+ledger_device_sdk = { version = "1.29.0", features = ["speculos"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ pin-project = "1.0.12"
 
 [dependencies.ledger-log]
 git = "https://github.com/alamgu/ledger-log"
+branch = "y333/rust_sdk_single_crate"
 optional = true
 
 [features]
@@ -38,8 +39,4 @@ ledger_device_sdk = { version = "1.28.0", features = ["speculos"] }
 
 [patch.crates-io]
 ledger_device_sdk = { git = "https://github.com/LedgerHQ/ledger-device-rust-sdk.git" }
-
-[patch."https://github.com/alamgu/ledger-log"]
-ledger-log = { path = "../../alamgu/ledger-log" }
-
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ pin-project = "1.0.12"
 
 [dependencies.ledger-log]
 git = "https://github.com/alamgu/ledger-log"
-branch = "y333/rust_sdk_single_crate"
 optional = true
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,16 @@ optional = true
 "logging" = [ "ledger-log" ]
 
 [target.'cfg(target_family = "bolos")'.dependencies]
-ledger_device_sdk = "1.5.1"
-ledger_secure_sdk_sys = "1.1.0"
+ledger_device_sdk = { version = "1.28.0" }
 
 [target.'cfg(target_family = "bolos")'.dev-dependencies]
 testmacro = "0.1.0"
-ledger_device_sdk = { version = "1.5.1", features = ["speculos"] }
+ledger_device_sdk = { version = "1.28.0", features = ["speculos"] }
+
+[patch.crates-io]
+ledger_device_sdk = { git = "https://github.com/LedgerHQ/ledger-device-rust-sdk.git" }
+
+[patch."https://github.com/alamgu/ledger-log"]
+ledger-log = { path = "../../alamgu/ledger-log" }
+
+


### PR DESCRIPTION
This PR updates the Ledger Rust SDK dependencies: sys crate is now available through the sys feature.
PR should be merged when the new ledger_device_sdk crate ( version > 1.28) will be published on crates.io.